### PR TITLE
Fix RTD by disabling docs in latex

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,12 @@
 build:
     image: latest
+formats:
+    - htmlzip
+    # Disable pdf because RTD can't handle converting svg to pdf (because an underlying converter
+    # such as `imagemagick` is required).
+    #- pdf
 python:
-    # Run on py 2 to ensure that we catch any missing imports
-    # This is convenient until we have better CI
+    # No strong preference between python versions since we have CI tests for python 2 and 3.
     version: 2
     pip_install: true
     extra_requirements:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - docker pull rehlers/overwatch:latest-py${DOCKER_PYTHON_VERSION}
     # Needed for ZODB python 3 compatibility
     - if [[ "${DOCKER_PYTHON_VERSION}" == "3."* ]]; then pip install git+https://github.com/SpotlightKid/flask-zodb.git; fi
-install: pip install --upgrade -e .[tests,dev]
+install: pip install --upgrade -e .[tests,dev,docs]
 before_script:
     # Runs the tests in a docker container. Necessary because we can't install ROOT easily here.
     # Further, we run in the tests directory to avoid any possible config.yaml interfering with the tests.
@@ -28,14 +28,17 @@ before_script:
     # send the results from inside the container to codecov. If we try to send afterwards from outside the container,
     # the paths will be wrong and the coverage report will fail!
     - ci_env=`bash <(curl -s https://codecov.io/env)`
-    - docker run -v ${PWD}:/opt/overwatch $ci_env rehlers/overwatch:latest-py${DOCKER_PYTHON_VERSION} /bin/bash -c "pip install --upgrade -e .[tests,dev]; cd tests; pytest -l --cov=overwatch --cov-branch --durations=5 . && bash <(curl -s https://codecov.io/bash)"
+    - docker run -v ${PWD}:/opt/overwatch $ci_env rehlers/overwatch:latest-py${DOCKER_PYTHON_VERSION} /bin/bash -c "pip install --upgrade -e .[tests,dev,docs]; cd tests; pytest -l --cov=overwatch --cov-branch --durations=5 . && bash <(curl -s https://codecov.io/bash)"
     # Install polymer and jsRoot so it they will be avialable and included in a built package
     # We can't easily install nodejs to install polymer and jsRoot, so instead, we extract it from the docker image.
     # Yes, it's super hacky, but it seems to work, so why not?
     - docker run -v ${PWD}/overwatch/webApp/static/:/opt/extractJS rehlers/overwatch:latest-py${DOCKER_PYTHON_VERSION} /bin/bash -c "cd overwatch/webApp/static && cp -r bower_components /opt/extractJS/. && cp -r jsRoot /opt/extractJS/."
 script:
-    # Since we ran the tests above, we just need to check code here.
+    # Since we ran the tests above, we don't need to run them here.
+    # Check code quality
     - flake8 .
+    # Check that the docs build successfully
+    - pushd doc && make html && popd
 after_success:
     # This will work for both tags and standard buidls. The build is performed for PRs, but it won't be deplyoed.
     # First, determine the Overwatch branch. If ${TRAVIS_BRANCH} is the same as ${TRAVIS_TAG}, then means that we're

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,6 +51,9 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
     'sphinx_markdown_tables',
+    # For converting svg to pdf when generating latex. This won't work on RTD because the underlying
+    # converter (such as `imagemagick`) is not available as of Oct 2018.
+    'sphinx.ext.imgconverter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Latex cannot be built because it can't handle svg images. There is a
conversion extension for sphinx (which we enable for good measure),
but it requires `imagemagick`, which is not available on RTD. So to
avoid breaking the docs build, we disable latex.