### PR TITLE
Remove combined file when converting subsystem

### DIFF
--- a/overwatch/processing/mergeFiles.py
+++ b/overwatch/processing/mergeFiles.py
@@ -239,8 +239,12 @@ def mergeRootFiles(runs, dirPrefix, forceNewMerge = False, cumulativeMode = True
         for subsystem in run.subsystems:
             # Only merge if we there are new files to merge
             if run.subsystems[subsystem].newFile is True or forceNewMerge:
+                # Convenience variable to prvoide direct access to the subsystem container.
+                # By defining here, it also means that the subsystem container details will be
+                # available for debugging.
+                subsystemObject = run.subsystems[subsystem]
                 # Skip if the subsystem does not have it's own files
-                if run.subsystems[subsystem].subsystem != run.subsystems[subsystem].fileLocationSubsystem:
+                if subsystemObject.subsystem != subsystemObject.fileLocationSubsystem:
                     continue
 
                 # Perform the merge

--- a/overwatch/processing/processRuns.py
+++ b/overwatch/processing/processRuns.py
@@ -731,8 +731,15 @@ def processMovedFilesIntoRuns(runs, runDict):
                                 subsystem.setupDirectories(runDir = runDir)
                                 logger.debug("Existing files: {filenames}".format(filenames = [f.filename for f in itervalues(subsystem.files)]))
                                 subsystem.files.clear()
+                                # Also need to remove the existing combined file. A new one will be generated
+                                # and added to the subsystem.
+                                subsystem.combinedFile = None
 
                         # Add the new files and note them in the subsystem, which will lead to reprocessing.
+                        # NOTE: Recall that the BTree that stores the files is a sorted object, so we don't
+                        #       need to worry about inserting files out of timestamp order - the new values
+                        #       will automatically be sorted by their keys, which will result in the entire
+                        #       files BTree sorted by time. This is exactly the desired structure!
                         subsystem.newFile = True
                         for filename in runDict[runDir][subsystemName]:
                             # We need the full path to the file (ie everything except for the dirPrefix).


### PR DESCRIPTION
When moving from fileLocationSubsystem to normal subsystem, we forgot to
update the combined files. Now we remove the combined file when
converting.

We also ensure that fileLocationSubsystem combined files are updated
after the standard subsystem combined files, so they point to the most
recent ones.

This is another attempt to fix OVERWATCH-PROCESSING-7 on sentry.